### PR TITLE
chore: plugin images

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -25,7 +25,7 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --configuration Release
+        run: dotnet build --configuration Release --no-restore
 
       - name: Test
         run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-kodisyncqueue'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish_release_draft:
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-kodisyncqueue'
+    
     steps:
       - name: Get version from GITHUB_REF
         id: get-version

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-kodisyncqueue'
+    
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5.15.0

--- a/README.md
+++ b/README.md
@@ -1,20 +1,49 @@
 <h1 align="center">Jellyfin Kodi Sync Queue Plugin</h1>
 <h3 align="center">Part of the <a href="https://jellyfin.org">Jellyfin Project</a></h3>
 
-## About
+<p align="center">
+<img alt="Plugin Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/plugins/SVG/jellyfin-plugin-kodisyncqueue.svg?sanitize=true"/>
+<br/>
+<br/>
+<a href="https://github.com/jellyfin/jellyfin-plugin-kodisyncqueue/actions?query=workflow%3A%22Test+Build+Plugin%22">
+<img alt="GitHub Workflow Status" src="https://img.shields.io/github/workflow/status/jellyfin/jellyfin-plugin-kodisyncqueue/Test%20Build%20Plugin.svg">
+</a>
+<a href="https://github.com/jellyfin/jellyfin-plugin-kodisyncqueue">
+<img alt="GPLv2 License" src="https://img.shields.io/github/license/jellyfin/jellyfin-plugin-kodisyncqueue.svg"/>
+</a>
+<a href="https://github.com/jellyfin/jellyfin-plugin-kodisyncqueue/releases">
+<img alt="Current Release" src="https://img.shields.io/github/release/jellyfin/jellyfin-plugin-kodisyncqueue.svg"/>
+</a>
+</p>
 
+## About
 This plugin will track all media changes while any Kodi clients are offline to decrease sync times when logging back in to your server.
 
-## Build & Installation Process
+## Installation
 
-1. Clone this repository
+[See the official documentation for install instructions](https://jellyfin.org/docs/general/server/plugins/index.html#installing).
 
-2. Ensure you have .NET Core SDK set up and installed
+## Build
 
-3. Build the plugin with your favorite IDE or the `dotnet` command
+1. To build this plugin you will need [.Net 5.x](https://dotnet.microsoft.com/download/dotnet/5.0).
 
-```sh
-dotnet publish --configuration Release --output bin
-```
+2. Build plugin with following command
+  ```
+  dotnet publish --configuration Release --output bin
+  ```
 
-4. Place the resulting file in a folder called `plugins` in the data directory
+3. Place the dll-file in the `plugins/kodisyncqueue` folder (you might need to create the folders) of your JF install
+
+## Releasing
+
+To release the plugin we recommend [JPRM](https://github.com/oddstr13/jellyfin-plugin-repository-manager) that will build and package the plugin.
+For additional context and for how to add the packaged plugin zip to a plugin manifest see the [JPRM documentation](https://github.com/oddstr13/jellyfin-plugin-repository-manager) for more info.
+
+## Contributing
+
+We welcome all contributions and pull requests! If you have a larger feature in mind please open an issue so we can discuss the implementation before you start.
+In general refer to our [contributing guidelines](https://github.com/jellyfin/.github/blob/master/CONTRIBUTING.md) for further information.
+
+## Licence
+
+This plugins code and packages are distributed under the GPLv2 License. See [LICENSE](./LICENSE) for more information.

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,7 @@
 ---
 name: "Kodi Sync Queue"
 guid: "771e19d6-5385-4caf-b35c-28a0e865cf63"
+imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-kodisyncqueue.png"
 version: "6.0.0.0"
 targetAbi: "10.7.0.0"
 framework: "net5.0"
@@ -9,7 +10,7 @@ overview: "Sync all media changes with Kodi clients"
 description: "This plugin will track all media changes while Kodi clients are offline to decrease sync times."
 category: "General"
 artifacts:
-- "Jellyfin.Plugin.KodiSyncQueue.dll"
-- "LiteDB.dll"
-changelog: >
+  - "Jellyfin.Plugin.KodiSyncQueue.dll"
+  - "LiteDB.dll"
+changelog: |
   changelog


### PR DESCRIPTION
* applies some smaller improvements to workflows
* updates readme with plugin-image
* adds plugin `imageUrl` to build.yaml

Merge Checklist:

* [x] either manually or via CI add plugin-images to [repo.jellyfin.org](https://repo.jellyfin.org/releases/plugin/)
* [x] ensure the plugin png is present within the plugin directory with the correct name on `repo.jellyfin.org`