### PR TITLE
Cleanup logging and naming

### DIFF
--- a/Jellyfin.Plugin.KodiSyncQueue/Data/DbRepo.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/Data/DbRepo.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.Data
             _logger = logger;
             _logger.LogInformation("Creating DB Repository...");
             Directory.CreateDirectory(dPath);
-            _liteDb = new LiteDatabase($"filename={dPath}/kodisyncqueue.db;mode=exclusive");
+            _liteDb = new LiteDatabase($"filename={dPath}/kodisyncqueue.db;mode=exclusive;upgrade=true");
             _jsonSerializerOptions = JsonDefaults.Options;
         }
 
@@ -60,8 +60,8 @@ namespace Jellyfin.Plugin.KodiSyncQueue.Data
         public void DeleteOldData(long dtl)
         {
             _logger.LogInformation("Starting Item and UserItem Retention Deletion...");
-            _liteDb.GetCollection<ItemRec>(ItemsCollection).Delete(x => x.LastModified < dtl);
-            _liteDb.GetCollection<UserInfoRec>(UserInfoCollection).Delete(x => x.LastModified < dtl);
+            _liteDb.GetCollection<ItemRec>(ItemsCollection).DeleteMany(x => x.LastModified < dtl);
+            _liteDb.GetCollection<UserInfoRec>(UserInfoCollection).DeleteMany(x => x.LastModified < dtl);
             _logger.LogInformation("Finished Item and UserItem Retention Deletion...");
         }
 

--- a/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/LibrarySyncNotification.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/LibrarySyncNotification.cs
@@ -155,7 +155,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
                 // Remove dupes in case some were saved multiple times
                 try
                 {
-                    _logger.LogInformation("Starting library sync...");
+                    _logger.LogInformation("Started library sync");
                     var startTime = DateTime.UtcNow;
                     var itemsAdded = _itemsAdded.GroupBy(i => i.Id)
                                         .Select(grp => grp.First())

--- a/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/LibrarySyncNotification.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/LibrarySyncNotification.cs
@@ -212,7 +212,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
 
                 _logger.LogDebug(
                     "Affected items: {Items}",
-                    string.Join(",", items.Select(i => i.Id.ToString("N", CultureInfo.InvariantCulture)).ToArray()));
+                    items.Select(i => i.Id.ToString("N", CultureInfo.InvariantCulture)));
             }
         }
 

--- a/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/LibrarySyncNotification.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/LibrarySyncNotification.cs
@@ -36,8 +36,6 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
             _libraryManager.ItemAdded += LibraryManager_ItemAdded;
             _libraryManager.ItemUpdated += LibraryManager_ItemUpdated;
             _libraryManager.ItemRemoved += LibraryManager_ItemRemoved;
-
-            _logger.LogInformation("LibrarySyncNotification Startup...");
             return Task.CompletedTask;
         }
 
@@ -71,7 +69,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
                     ItemType = type,
                 };
 
-                _logger.LogDebug("ItemAdded added for DB Saving {ItemId}", e.Item.Id);
+                _logger.LogDebug("Item creation queued because {ItemId} was added to database", e.Item.Id);
                 _itemsAdded.Add(item);
             }
         }
@@ -106,7 +104,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
                     ItemType = type
                 };
 
-                _logger.LogDebug("ItemUpdated added for DB Saving {ItemId}", e.Item.Id);
+                _logger.LogDebug("Item update queued because {ItemId} was modified", e.Item.Id);
                 _itemsUpdated.Add(item);
             }
         }
@@ -141,7 +139,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
                     ItemType = type
                 };
 
-                _logger.LogDebug("ItemRemoved added for DB Saving {ItemId}", e.Item.Id);
+                _logger.LogDebug("Item removal queued because {ItemId} was removed from library", e.Item.Id);
                 _itemsRemoved.Add(item);
             }
         }
@@ -157,13 +155,14 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
                 // Remove dupes in case some were saved multiple times
                 try
                 {
-                    _logger.LogInformation("Starting Library Sync...");
+                    _logger.LogInformation("Starting library sync...");
                     var startTime = DateTime.UtcNow;
-
-                    var itemsAdded = _itemsAdded.GroupBy(i => i.Id).Select(grp => grp.First()).ToList();
-
-                    var itemsRemoved = _itemsRemoved.GroupBy(i => i.Id).Select(grp => grp.First()).ToList();
-
+                    var itemsAdded = _itemsAdded.GroupBy(i => i.Id)
+                                        .Select(grp => grp.First())
+                                        .ToList();
+                    var itemsRemoved = _itemsRemoved.GroupBy(i => i.Id)
+                                        .Select(grp => grp.First())
+                                        .ToList();
                     var itemsUpdated = _itemsUpdated
                                         .Where(i => itemsAdded.FirstOrDefault(a => a.Id == i.Id) == null)
                                         .GroupBy(g => g.Id)
@@ -179,11 +178,11 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
                     }
 
                     TimeSpan dateDiff = DateTime.UtcNow - startTime;
-                    _logger.LogInformation("Finished Library Sync Taking {TimeTaken}", dateDiff.ToString("c", CultureInfo.InvariantCulture));
+                    _logger.LogInformation("Finished library sync, taking {TimeTaken}", dateDiff.ToString("c", CultureInfo.InvariantCulture));
                 }
                 catch (Exception e)
                 {
-                    _logger.LogError(e, "An Error Has Occurred in LibraryUpdateTimerCallback");
+                    _logger.LogError(e, "An error has occurred in LibraryUpdateTimerCallback");
                 }
 
                 _itemsAdded.Clear();
@@ -202,12 +201,19 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
         private void UpdateLibrary(IReadOnlyCollection<LibItem> items, ItemStatus status)
         {
             KodiSyncQueuePlugin.Instance.DbRepo.WriteLibrarySync(items, status);
+            var itemCount = items.Count;
 
-            _logger.LogInformation(
-                "\"LIBRARYSYNC\" {StatusType} {NumberOfItems} items:  {Items}",
-                status,
-                items.Count,
-                string.Join(",", items.Select(i => i.Id.ToString("N", CultureInfo.InvariantCulture)).ToArray()));
+            if (itemCount > 0)
+            {
+                _logger.LogInformation(
+                    "Library Sync: {StatusType} {NumberOfItems} items",
+                    status,
+                    items.Count);
+
+                _logger.LogDebug(
+                    "Affected items: {Items}",
+                    string.Join(",", items.Select(i => i.Id.ToString("N", CultureInfo.InvariantCulture)).ToArray()));
+            }
         }
 
         private void TriggerCancellation()

--- a/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/UserSyncNotification.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/UserSyncNotification.cs
@@ -132,7 +132,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var userId = pair.Key;
-                _logger.LogDebug("Started saving items for {userId}", userId.ToString());
+                _logger.LogDebug("Started saving items for {userId}", userId);
 
                 var user = _userManager.GetUserById(userId);
 
@@ -167,7 +167,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
 
                 _logger.LogDebug(
                     "Updated items: {Updates}",
-                    ids.ToArray());
+                    ids);
             }
         }
 

--- a/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/UserSyncNotification.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/UserSyncNotification.cs
@@ -99,7 +99,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
             {
                 try
                 {
-                    _logger.LogInformation("Starting user data sync...");
+                    _logger.LogInformation("Started user data sync");
                     var startDate = DateTime.UtcNow;
 
                     // Remove dupes in case some were saved multiple times
@@ -132,7 +132,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var userId = pair.Key;
-                _logger.LogDebug("Starting to save items for {userId}", userId.ToString());
+                _logger.LogDebug("Started saving items for {userId}", userId.ToString());
 
                 var user = _userManager.GetUserById(userId);
 
@@ -160,14 +160,14 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
             if (itemCount > 0)
             {
                 _logger.LogInformation(
-                    "User Data Sync: User {UserId}({Username}) posted {NumberOfUpdates} updates",
-                    userId,
+                    "User Data Sync: User {UserName} ({UserId}) posted {NumberOfUpdates} updates",
                     userName,
+                    userId,
                     itemCount);
 
                 _logger.LogDebug(
                     "Updated items: {Updates}",
-                    string.Join(",", ids.ToArray()));
+                    ids.ToArray());
             }
         }
 

--- a/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/UserSyncNotification.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/UserSyncNotification.cs
@@ -38,7 +38,6 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
         {
             _userDataManager.UserDataSaved += UserDataManager_UserDataSaved;
 
-            _logger.LogInformation("UserSyncNotification Startup...");
             return Task.CompletedTask;
         }
 
@@ -100,7 +99,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
             {
                 try
                 {
-                    _logger.LogInformation("Starting User Changes Sync...");
+                    _logger.LogInformation("Starting user data sync...");
                     var startDate = DateTime.UtcNow;
 
                     // Remove dupes in case some were saved multiple times
@@ -118,11 +117,11 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
                     }
 
                     TimeSpan dateDiff = DateTime.UtcNow - startDate;
-                    _logger.LogInformation("User Changes Sync Finished Taking {TimeTaken}", dateDiff.ToString("c", CultureInfo.InvariantCulture));
+                    _logger.LogInformation("Finished user data sync, taking {TimeTaken}", dateDiff.ToString("c", CultureInfo.InvariantCulture));
                 }
                 catch (Exception e)
                 {
-                    _logger.LogError(e, "An Error Has Occurred in UserUpdateTimerCallback");
+                    _logger.LogError(e, "An error has occurred in UserUpdateTimerCallback");
                 }
             }
         }
@@ -156,8 +155,20 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
         {
             KodiSyncQueuePlugin.Instance.DbRepo.SetUserInfoSync(dtos, itemRefs, userId);
             List<string> ids = dtos.Select(s => s.ItemId).ToList();
+            var itemCount = ids.Count;
 
-            _logger.LogInformation("\"USERSYNC\" User {UserId}({Username}) posted {NumberOfUpdates} Updates: {Updates}", userId, userName, ids.Count, string.Join(",", ids.ToArray()));
+            if (itemCount > 0)
+            {
+                _logger.LogInformation(
+                    "User Data Sync: User {UserId}({Username}) posted {NumberOfUpdates} updates",
+                    userId,
+                    userName,
+                    itemCount);
+
+                _logger.LogDebug(
+                    "Updated items: {Updates}",
+                    string.Join(",", ids.ToArray()));
+            }
         }
 
         private void TriggerCancellation()

--- a/Jellyfin.Plugin.KodiSyncQueue/Jellyfin.Plugin.KodiSyncQueue.csproj
+++ b/Jellyfin.Plugin.KodiSyncQueue/Jellyfin.Plugin.KodiSyncQueue.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Jellyfin.Data" Version="10.*-*" />
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-    <PackageReference Include="LiteDB" Version="4.1.4" />
+    <PackageReference Include="LiteDB" Version="5.0.12" />
   </ItemGroup>
 
   <!-- Code Analyzers-->

--- a/Jellyfin.Plugin.KodiSyncQueue/KodiSyncQueuePlugin.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/KodiSyncQueuePlugin.cs
@@ -21,7 +21,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue
             Instance = this;
 
             var logger = loggerFactory.CreateLogger<KodiSyncQueuePlugin>();
-            logger.LogInformation("Jellyfin.Plugin.KodiSyncQueue is now starting");
+            logger.LogInformation("KodiSyncQueue is starting...");
 
             DbRepo = new DbRepo(applicationPaths.DataPath, loggerFactory.CreateLogger<DbRepo>());
         }

--- a/Jellyfin.Plugin.KodiSyncQueue/ScheduledTasks/RetentionTask.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/ScheduledTasks/RetentionTask.cs
@@ -19,9 +19,9 @@ namespace Jellyfin.Plugin.KodiSyncQueue.ScheduledTasks
 
         public string Name => "Remove Old Sync Data";
 
-        public string Category => "Jellyfin.Plugin.KodiSyncQueue";
+        public string Category => "KodiSyncQueue";
 
-        public string Description => "If Retention Days > 0 then this will remove the old data to keep information flowing quickly";
+        public string Description => "If retention days > 0 then this will remove the old data to keep information flowing quickly";
 
         public string Key => "KodiSyncFireRetentionTask";
 
@@ -30,7 +30,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.ScheduledTasks
             // Is retDays 0.. If So Exit...
             if (!int.TryParse(KodiSyncQueuePlugin.Instance.Configuration.RetDays, out var retDays) || retDays == 0)
             {
-                _logger.LogInformation("Retention Deletion Not Possible When Retention Days = 0!");
+                _logger.LogInformation("Retention deletion not possible if retention days is set to zero!");
                 return Task.CompletedTask;
             }
 

--- a/Jellyfin.Plugin.KodiSyncQueue/ScheduledTasks/RetentionTask.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/ScheduledTasks/RetentionTask.cs
@@ -14,12 +14,12 @@ namespace Jellyfin.Plugin.KodiSyncQueue.ScheduledTasks
         public RetentionTask(ILogger<RetentionTask> logger)
         {
             _logger = logger;
-            _logger.LogInformation("Retention Task Scheduled!");
+            _logger.LogInformation("Retention task scheduled");
         }
 
         public string Name => "Remove Old Sync Data";
 
-        public string Category => "KodiSyncQueue";
+        public string Category => "Kodi Sync Queue";
 
         public string Description => "If retention days > 0 then this will remove the old data to keep information flowing quickly";
 

--- a/Jellyfin.Plugin.KodiSyncQueue/Web/kodisyncqueue.html
+++ b/Jellyfin.Plugin.KodiSyncQueue/Web/kodisyncqueue.html
@@ -15,7 +15,7 @@
                     </label>
                 </div>
                 <div class="verticalSection verticalSection-extrabottompadding">
-                    <h2>Items to Track</h2>
+                    <h2>Items to track</h2>
                     <div class="checkboxContainer">
                         <label class="emby-checkbox-label">
                             <input is="emby-checkbox" type="checkbox" id="tkMovies" />


### PR DESCRIPTION
This bothered me for way too long:
* Only log something if something actually changed
* Omit logging item ids if debugging isn't enabled
* Make log messages more clear
* Fix the scheduled task section name
* Upgrades LiteDB to v5, fixes incompatibilities and adds `upgrade=true` to connection string to automatically upgrade the database