### PR TITLE
Downgrade LiteDB to 5.0.15

### DIFF
--- a/Jellyfin.Plugin.KodiSyncQueue/Jellyfin.Plugin.KodiSyncQueue.csproj
+++ b/Jellyfin.Plugin.KodiSyncQueue/Jellyfin.Plugin.KodiSyncQueue.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Jellyfin.Data" Version="10.*-*" />
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-    <PackageReference Include="LiteDB" Version="5.0.19" />
+    <PackageReference Include="LiteDB" Version="5.0.15" />
   </ItemGroup>
 
   <!-- Code Analyzers-->


### PR DESCRIPTION
Hopefully works around #83 and #84

Likely fixes the former, not sure about the latter.


Not a proper fix, just a workaround.

Migrating to SQLite in the future would likely be desirable.