### PR TITLE
Implement a database upgrade system, properly migrate ItemId to Guid

### DIFF
--- a/Jellyfin.Plugin.KodiSyncQueue/Entities/UserInfoRec.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/Entities/UserInfoRec.cs
@@ -1,10 +1,12 @@
+using System;
+
 namespace Jellyfin.Plugin.KodiSyncQueue.Entities
 {
     public class UserInfoRec
     {
         public int Id { get; set; }
 
-        public string ItemId { get; set; }
+        public Guid ItemId { get; set; }
 
         public string UserId { get; set; }
 

--- a/Jellyfin.Plugin.KodiSyncQueue/Entities/UserJson.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/Entities/UserJson.cs
@@ -1,8 +1,10 @@
+using System;
+
 namespace Jellyfin.Plugin.KodiSyncQueue.Entities
 {
     public class UserJson
     {
-        public string Id { get; set; }
+        public Guid Id { get; set; }
 
         public string JsonData { get; set; }
     }


### PR DESCRIPTION
In v12, the ItemId column in UserInfoRec was changed from a `string` to a `Guid` (#97). In v13, released 3 days later, it was changed back to a `string` (#100). However, anyone who added media to their library with v12 now has unusable database entries since the types no longer match.

This PR adds a generic system for upgrading the database and uses it to convert any `Guid` types back to strings.

Fixes #104 / #105.

I'm leaving this as a draft since I don't currently have access to my Jellyfin server to test it, although it should™ be good to go if others would like to test it first (with a db backup!).