### PR TITLE
fix: add authentication for sync queue API

### DIFF
--- a/Jellyfin.Plugin.KodiSyncQueue/API/KodiSyncQueueController.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/API/KodiSyncQueueController.cs
@@ -8,10 +8,12 @@ using System.Linq;
 using System.Net.Mime;
 using System.Text.Json;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Extensions;
 using Jellyfin.Extensions.Json;
 using Jellyfin.Plugin.KodiSyncQueue.Entities;
 using Jellyfin.Plugin.KodiSyncQueue.Utils;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Net;
 using MediaBrowser.Model.Dto;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -46,10 +48,12 @@ namespace Jellyfin.Plugin.KodiSyncQueue.API
         /// <returns>The <see cref="SyncUpdateInfo"/>.</returns>
         [HttpGet("Jellyfin.Plugin.KodiSyncQueue/{userId}/GetItems")]
         public ActionResult<SyncUpdateInfo> GetLibraryItemsQuery(
-            [FromRoute] string userId,
+            [FromRoute] Guid userId,
             [FromQuery] string? lastUpdateDt,
             [FromQuery] string? filter)
         {
+            userId = GetUserId(User, userId);
+
             _logger.LogInformation("Sync Requested for UserID: '{UserId}' with LastUpdateDT: '{LastUpdateDT}'", userId, lastUpdateDt);
             if (string.IsNullOrEmpty(lastUpdateDt))
             {
@@ -237,7 +241,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.API
         }
 
         private SyncUpdateInfo PopulateLibraryInfo(
-            string userId,
+            Guid userId,
             string lastRequestedDt,
             IReadOnlyCollection<MediaType> filters)
         {
@@ -247,7 +251,7 @@ namespace Jellyfin.Plugin.KodiSyncQueue.API
 
             var userDt = DateTime.Parse(lastRequestedDt, CultureInfo.CurrentCulture, DateTimeStyles.AssumeUniversal);
             var dtl = (long)userDt.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
-            var user = _userManager.GetUserById(Guid.Parse(userId));
+            var user = _userManager.GetUserById(userId);
             if (user is null)
             {
                 throw new InvalidOperationException("Unknown user");
@@ -274,6 +278,39 @@ namespace Jellyfin.Plugin.KodiSyncQueue.API
             _logger.LogInformation("Request Finished Taking {TimeTaken}", diffDate.ToString("c", CultureInfo.InvariantCulture));
 
             return info;
+        }
+
+        /// <summary>
+        /// Checks if the user can access a user. <br />
+        /// Original source: https://github.com/jellyfin/jellyfin/blob/086fbd49cfba3dcdb27ba8b37ff25722e9b37fb4/Jellyfin.Api/Helpers/RequestHelpers.cs#L67. <br />
+        /// </summary>
+        /// <param name="claimsPrincipal">The <see cref="ClaimsPrincipal"/> for the current request.</param>
+        /// <param name="userId">The user id.</param>
+        /// <returns>A <see cref="bool"/> whether the user can access the user.</returns>
+        private static Guid GetUserId(System.Security.Claims.ClaimsPrincipal claimsPrincipal, Guid? userId)
+        {
+            var claimValue = claimsPrincipal.Claims.FirstOrDefault(claim => claim.Type.Equals("Jellyfin-UserId", StringComparison.OrdinalIgnoreCase))?.Value;
+            if (string.IsNullOrEmpty(claimValue))
+            {
+                throw new SecurityException("Invalid token.");
+            }
+
+            var authenticatedUserId = Guid.Parse(claimValue);
+
+            // UserId not provided, fall back to authenticated user id.
+            if (userId.IsNullOrEmpty())
+            {
+                return authenticatedUserId;
+            }
+
+            // User must be administrator to access another user.
+            var isAdministrator = claimsPrincipal.IsInRole("Administrator");
+            if (!userId.Value.Equals(authenticatedUserId) && !isAdministrator)
+            {
+                throw new SecurityException("Forbidden");
+            }
+
+            return userId.Value;
         }
     }
 }

--- a/Jellyfin.Plugin.KodiSyncQueue/API/KodiSyncQueueController.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/API/KodiSyncQueueController.cs
@@ -13,12 +13,14 @@ using Jellyfin.Plugin.KodiSyncQueue.Entities;
 using Jellyfin.Plugin.KodiSyncQueue.Utils;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Dto;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.KodiSyncQueue.API
 {
     [ApiController]
+    [Authorize]
     [Produces(MediaTypeNames.Application.Json)]
     public class KodiSyncQueueController : ControllerBase
     {

--- a/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/UserSyncNotification.cs
+++ b/Jellyfin.Plugin.KodiSyncQueue/EntryPoints/UserSyncNotification.cs
@@ -141,11 +141,11 @@ namespace Jellyfin.Plugin.KodiSyncQueue.EntryPoints
                         })
                         .ToList();
 
-                SaveUserChanges(dtoList, itemRefs, user.Username, userId.ToString("N", CultureInfo.InvariantCulture));
+                SaveUserChanges(dtoList, itemRefs, user.Username, userId);
             }
         }
 
-        private void SaveUserChanges(List<MediaBrowser.Model.Dto.UserItemDataDto> dtos, List<LibItem> itemRefs, string userName, string userId)
+        private void SaveUserChanges(List<MediaBrowser.Model.Dto.UserItemDataDto> dtos, List<LibItem> itemRefs, string userName, Guid userId)
         {
             KodiSyncQueuePlugin.Instance.DbRepo.SetUserInfoSync(dtos, itemRefs, userId);
             List<Guid> ids = dtos.Select(s => s.ItemId).ToList();


### PR DESCRIPTION
I have just reviewed the security of my Jellyfin server and figured out that the API of the Kodi Sync queue plugin is completely unauthenticated.
This allows anyone to fetch the entire playback history of an user as long as they know the UserID.

Since the Kodi plugin sends the authorization token for all Jellyfin requests, there is no reason to leave the sync queue endpoints unprotected. I have just updated the plugin on my server and Kodi synchronization works as expected. 