### PR TITLE
Unstable: Update to latest Jellyfin preview packages

### DIFF
--- a/Jellyfin.Plugin.KodiSyncQueue/Jellyfin.Plugin.KodiSyncQueue.csproj
+++ b/Jellyfin.Plugin.KodiSyncQueue/Jellyfin.Plugin.KodiSyncQueue.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Data" Version="10.*-*" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Data" Version="12.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.*-*" />
     <PackageReference Include="LiteDB" Version="5.0.15" />
   </ItemGroup>
 

--- a/Jellyfin.Plugin.KodiSyncQueue/Jellyfin.Plugin.KodiSyncQueue.csproj
+++ b/Jellyfin.Plugin.KodiSyncQueue/Jellyfin.Plugin.KodiSyncQueue.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/build.yaml
+++ b/build.yaml
@@ -4,7 +4,7 @@ guid: "771e19d6-5385-4caf-b35c-28a0e865cf63"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-kodisyncqueue.png"
 version: 15
 targetAbi: "12.0.0.0"
-framework: "net9.0"
+framework: "net10.0"
 owner: "jellyfin"
 overview: "Sync all media changes with Kodi clients"
 description: "This plugin will track all media changes while Kodi clients are offline to decrease sync times."

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ name: "Kodi Sync Queue"
 guid: "771e19d6-5385-4caf-b35c-28a0e865cf63"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-kodisyncqueue.png"
 version: 15
-targetAbi: "10.11.0.0"
+targetAbi: "10.12.0.0"
 framework: "net9.0"
 owner: "jellyfin"
 overview: "Sync all media changes with Kodi clients"

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ name: "Kodi Sync Queue"
 guid: "771e19d6-5385-4caf-b35c-28a0e865cf63"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-kodisyncqueue.png"
 version: 15
-targetAbi: "10.12.0.0"
+targetAbi: "12.0.0.0"
 framework: "net9.0"
 owner: "jellyfin"
 overview: "Sync all media changes with Kodi clients"


### PR DESCRIPTION
Update Jellyfin NuGet package version to `10.*-*`.